### PR TITLE
Basic commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,56 @@
         "mime-types": "^2.1.12"
       }
     },
+    "@sindresorhus/is": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.1.tgz",
+      "integrity": "sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg=="
+    },
+    "@szmarczak/http-timer": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
+      "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
+      "requires": {
+        "defer-to-connect": "^2.0.0"
+      }
+    },
+    "@types/cacheable-request": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
+      "integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
+      "requires": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "*",
+        "@types/node": "*",
+        "@types/responselike": "*"
+      }
+    },
+    "@types/http-cache-semantics": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
+      "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A=="
+    },
+    "@types/keyv": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
+      "integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz",
+      "integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA=="
+    },
+    "@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -37,6 +87,33 @@
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
+    "cacheable-lookup": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.3.tgz",
+      "integrity": "sha512-W+JBqF9SWe18A72XFzN/V/CULFzPm7sBXzzR6ekkE+3tLG72wFZrBiBZhrZuDoYexop4PHJVdFAKb/Nj9+tm9w=="
+    },
+    "cacheable-request": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
+      "integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^2.0.0"
+      }
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -44,6 +121,26 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "requires": {
+        "mimic-response": "^3.1.0"
+      },
+      "dependencies": {
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+        }
+      }
+    },
+    "defer-to-connect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
+      "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg=="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -65,6 +162,14 @@
         "ws": "^7.2.1"
       }
     },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
     "event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -81,10 +186,56 @@
         "universalify": "^1.0.0"
       }
     },
+    "get-stream": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+      "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
+    "got": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.1.4.tgz",
+      "integrity": "sha512-z94KIXHhFSpJONuY6C6w1wC+igE7P1d0b5h3H2CvrOXn0/tum/OgFblIGUAxI5PBXukGLvKb9MJXVHW8vsYaBA==",
+      "requires": {
+        "@sindresorhus/is": "^2.1.1",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.1",
+        "decompress-response": "^6.0.0",
+        "get-stream": "^5.1.0",
+        "http2-wrapper": "^1.0.0-beta.4.5",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+    },
+    "http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+    },
+    "http2-wrapper": {
+      "version": "1.0.0-beta.4.6",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.0-beta.4.6.tgz",
+      "integrity": "sha512-9oB4BiGDTI1FmIBlOF9OJ5hwJvcBEmPCqk/hy314Uhy2uq5TjekUZM8w8SPLLlUEM+mxNhXdPAXfrJN2Zbb/GQ==",
+      "requires": {
+        "quick-lru": "^5.0.0",
+        "resolve-alpn": "^1.0.0"
+      }
+    },
+    "json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
     "jsonfile": {
       "version": "6.0.1",
@@ -94,6 +245,19 @@
         "graceful-fs": "^4.1.6",
         "universalify": "^1.0.0"
       }
+    },
+    "keyv": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.1.tgz",
+      "integrity": "sha512-xz6Jv6oNkbhrFCvCP7HQa8AaII8y8LRpoSm661NOKLr4uHuBwhX4epXrPQgF3+xdJnN4Esm5X0xwY4bOlALOtw==",
+      "requires": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
     },
     "mime-db": {
       "version": "1.44.0",
@@ -108,15 +272,65 @@
         "mime-db": "1.44.0"
       }
     },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+    },
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
+    "normalize-url": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "p-cancelable": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
+      "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg=="
+    },
     "prism-media": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.2.2.tgz",
       "integrity": "sha512-I+nkWY212lJ500jLe4tN9tWO7nRiBAVdMv76P9kffZjYhw20raMlW1HSSvS+MLXC9MmbNZCazMrAr+5jEEgTuw=="
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "quick-lru": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.0.tgz",
+      "integrity": "sha512-WjAKQ9ORzvqjLijJXiXWqc3Gcs1ivoxCj6KJmEjoWBE6OtHwuaDLSAUqGHALUiid7A1KqGqsSHZs8prxF5xxAQ=="
+    },
+    "resolve-alpn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.0.0.tgz",
+      "integrity": "sha512-rTuiIEqFmGxne4IovivKSDzld2lWW9QCjqv80SYjPgf+gS35eaCAjaP54CCwGAwBtnCsvNLYtqxe1Nw+i6JEmA=="
+    },
+    "responselike": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+      "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+      "requires": {
+        "lowercase-keys": "^2.0.0"
+      }
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -132,6 +346,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
       "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
       "version": "7.3.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/wakfi/suki#readme",
   "dependencies": {
     "discord.js": "^12.2.0",
-    "fs-extra": "^9.0.0"
+    "fs-extra": "^9.0.0",
+    "got": "^11.1.4"
   }
 }

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,0 +1,137 @@
+const path = require('path');
+const MessageEmbed = require((require.resolve('discord.js')).split(path.sep).slice(0, -1).join(path.sep) + `${path.sep}structures${path.sep}MessageEmbed.js`);
+const authorReply = require('../util/authorReply.js');
+const {prefix,permLevels} = require('../components/config.js');
+
+const levelCache = {};
+for (let i = 0; i < permLevels.length; i++) 
+{
+	const thisLevel = permLevels[i];
+	levelCache[thisLevel.name] = thisLevel.level;
+}
+
+const permlevel = (message) => {
+	let permlvl = 0;
+
+	const permOrder = permLevels.slice(0).sort((p, c) => p.level < c.level ? 1 : -1);
+
+	while (permOrder.length) {
+		const currentLevel = permOrder.shift();
+		if (message.guild && currentLevel.guildOnly) continue;
+		if (currentLevel.check(message)) {
+			permlvl = currentLevel.level;
+			break;
+		}
+	}
+	return permlvl;
+}
+
+module.exports = {
+	name: 'help',
+	description: 'Provides information about all commands, as well as information about specific commands',
+	category: 'basic',
+	usage: `[commandName]\n${prefix}<command> -h`,
+	aliases: ['commands','command','?'],
+	permLevel: 'User',
+	guildOnly: false,
+	dmOnly: false,
+	args: false,
+	noArgs: false,
+	async execute(message, args) {
+		const level = permlevel(message);
+		const commands = message.client.commands.sorted((p, c) => levelCache[p.permLevel] < levelCache[c.permLevel] ? -1 : 1);
+		if(args.length == 0)
+		{
+			const embeds = [];
+			embeds[0] = new MessageEmbed()
+				.setTitle(`Suki Help`)
+				.setAuthor(message.client.user.username, message.client.user.avatarURL)
+				.setDescription(`Please contact <@193160566334947340> with additional questions`)
+				.setColor(0xFF00FF)
+			let previousCMDLevel = levelCache[commands.first().permLevel];
+			let cmdArr = [[]];
+			let count = 0;
+			let cmdIndex = 0;
+			commands.forEach(cmd => 
+			{
+				cmdArr[cmdIndex].push(cmd);
+				count++;
+				if(count == 25)
+				{
+					cmdArr.push([]);
+					cmdIndex++;
+					count = 0;
+					embeds[cmdIndex] = new MessageEmbed()
+						.setColor(0xFF00FF);
+				}
+			});
+			
+			let modified = false;
+			cmdIndex = 0;
+			count = 0;
+			const checkCount = () => {
+				if(count == 25) 
+				{
+					cmdIndex++;
+					if(cmdIndex == embeds.length)
+					{
+						embeds.push(new MessageEmbed()
+							.setColor(0xFF00FF)
+						);
+						count = 0;
+					}
+				}
+			};
+			cmdArr.forEach(subArr => {
+				if(modified) 
+				{
+					cmdIndex--;
+				}
+				const embed = embeds[cmdIndex];
+				subArr.forEach(cmd => {
+					cmdLevel = levelCache[cmd.permLevel];
+					if(level >= cmdLevel)
+					{
+						if(cmdLevel > previousCMDLevel)
+						{
+							embed.addField(`\u200b`, `**Additional commands for: ${cmd.permLevel}**`);
+							previousCMDLevel = cmdLevel;
+							count++;
+						}
+						checkCount();
+						/*if(count == 25) 
+						{
+							cmdIndex++;
+							if(cmdIndex == embeds.length)
+							{
+								embeds.push(new MessageEmbed()
+									.setColor(0xFF00FF);
+								);
+								count = 0;
+							}
+						}*/
+						let fieldBody = ``;
+						if(cmd.description) fieldBody += `Description: ${cmd.description}\n`;
+						fieldBody += `Usage: ${prefix}${cmd.name} ${cmd.usage?cmd.usage:''}\n`;
+						if(cmd.category) fieldBody += `Category: ${cmd.category}\n`;
+						if(cmd.aliases) fieldBody += `Aliases: ${cmd.aliases.join(', ')}\n`;
+						if(cmd.guildOnly) fieldBody += `*This command can only be used in a server channel*\n`;
+						if(cmd.dmOnly) fieldBody += `*This command can only be used in a direct message*\n`;
+						embed.addField(`${prefix}${cmd.name}`,fieldBody.trim());
+						count++;
+						checkCount();
+					}
+				});
+				cmdIndex++;
+			});
+			const embedsToSend = embeds.filter(embed => embed.fields.length > 0);
+			embedsToSend[embedsToSend.length-1]
+				.setFooter(`${prefix}commands, ${prefix}command, ${prefix}?`)
+				.setTimestamp(new Date());
+			embedsToSend.forEach(async embed => await authorReply(message,embed));
+		} else {
+			const commandName = args.shift();
+			
+		}
+	}
+};

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -29,14 +29,10 @@ const permlevel = (message) => {
 module.exports = {
 	name: 'help',
 	description: 'Provides information about all commands, as well as information about specific commands',
-	category: 'general',
+	category: 'information',
 	usage: [`[commandName]\n\u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b ${prefix}<command> -h`],
 	aliases: ['commands','command','?'],
 	permLevel: 'User',
-	guildOnly: false,
-	dmOnly: false,
-	args: false,
-	noArgs: false,
 	async execute(message, args) {
 		const level = permlevel(message);
 		const commands = message.client.commands.sorted((p, c) => levelCache[p.permLevel] < levelCache[c.permLevel] ? -1 : 1);

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -29,8 +29,8 @@ const permlevel = (message) => {
 module.exports = {
 	name: 'help',
 	description: 'Provides information about all commands, as well as information about specific commands',
-	category: 'basic',
-	usage: `[commandName]\n${prefix}<command> -h`,
+	category: 'general',
+	usage: [`[commandName]\n\u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b ${prefix}<command> -h`],
 	aliases: ['commands','command','?'],
 	permLevel: 'User',
 	guildOnly: false,
@@ -42,12 +42,12 @@ module.exports = {
 		const commands = message.client.commands.sorted((p, c) => levelCache[p.permLevel] < levelCache[c.permLevel] ? -1 : 1);
 		if(args.length == 0)
 		{
+			// ?help
 			const embeds = [];
 			embeds[0] = new MessageEmbed()
-				.setTitle(`Suki Help`)
-				.setAuthor(message.client.user.username, message.client.user.avatarURL)
-				.setDescription(`Please contact <@193160566334947340> with additional questions`)
-				.setColor(0xFF00FF)
+				.setTitle(`${message.client.user.username} Help`)//, message.client.user.displayAvatarURL())
+				.setDescription(`Send \`${prefix}command -h\` with any command for more information about that command`)
+				.setColor(0xFF00FF);
 			let previousCMDLevel = levelCache[commands.first().permLevel];
 			let cmdArr = [[]];
 			let count = 0;
@@ -99,24 +99,13 @@ module.exports = {
 							count++;
 						}
 						checkCount();
-						/*if(count == 25) 
-						{
-							cmdIndex++;
-							if(cmdIndex == embeds.length)
-							{
-								embeds.push(new MessageEmbed()
-									.setColor(0xFF00FF);
-								);
-								count = 0;
-							}
-						}*/
 						let fieldBody = ``;
-						if(cmd.description) fieldBody += `Description: ${cmd.description}\n`;
-						fieldBody += `Usage: ${prefix}${cmd.name} ${cmd.usage?cmd.usage:''}\n`;
-						if(cmd.category) fieldBody += `Category: ${cmd.category}\n`;
-						if(cmd.aliases) fieldBody += `Aliases: ${cmd.aliases.join(', ')}\n`;
-						if(cmd.guildOnly) fieldBody += `*This command can only be used in a server channel*\n`;
-						if(cmd.dmOnly) fieldBody += `*This command can only be used in a direct message*\n`;
+						//if(cmd.aliases) fieldBody += `Alias(es): ${cmd.aliases.join(', ')}\n`;
+						fieldBody += `Description: ${cmd.description}\n`;
+						//fieldBody += `Usage: ${prefix}${cmd.name} ${cmd.usage?cmd.usage.join('\\n       ' + prefix + cmd.name):''}\n`;
+						//if(cmd.category) fieldBody += `Category: ${cmd.category}\n`;
+						//if(cmd.guildOnly) fieldBody += `*This command can only be used in a server channel*\n`;
+						//if(cmd.dmOnly) fieldBody += `*This command can only be used in a direct message*\n`;
 						embed.addField(`${prefix}${cmd.name}`,fieldBody.trim());
 						count++;
 						checkCount();
@@ -130,8 +119,24 @@ module.exports = {
 				.setTimestamp(new Date());
 			embedsToSend.forEach(async embed => await authorReply(message,embed));
 		} else {
+			// ?command -h
 			const commandName = args.shift();
-			
+			if(!message.client.commands.has(commandName)) return;
+			const command = message.client.commands.get(commandName);
+			let fieldBody = ``;
+			if(command.aliases) fieldBody += `Alias(es): ${command.aliases.join(', ')}\n`;
+			fieldBody += `Description: ${command.description ? command.description : command.name.charAt(0).toUpperCase() + command.name.slice(1)}\n`;
+			fieldBody += `Usage: ${prefix}${command.name} ${command.usage ? command.usage.join('\n\u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b \u200b ' + prefix + command.name + ' ') : ''}\n`;
+			if(command.category) fieldBody += `Category: ${command.category}\n`;
+			if(command.guildOnly) fieldBody += `*This command can only be used in a server channel*\n`;
+			else if(command.dmOnly) fieldBody += `*This command can only be used in a direct message*\n`;
+			const embed = new MessageEmbed()
+				.setTitle(`${prefix}${command.name}`)
+				.setColor(0xFF00FF)
+				.addField(`${command.permLevel==='User' ? 'Available to all users' : 'Restricted to: ' + command.permLevel}`, fieldBody.trim())
+				.setFooter(`\`<arg>\` denotes required arguments; \`[arg]\` denotes optional arguments`)
+				.setTimestamp(new Date());
+			authorReply(message, embed);
 		}
 	}
 };

--- a/src/commands/info.js
+++ b/src/commands/info.js
@@ -1,0 +1,34 @@
+const got = require('got');
+const path = require('path');
+const MessageEmbed = require((require.resolve('discord.js')).split(path.sep).slice(0, -1).join(path.sep) + `${path.sep}structures${path.sep}MessageEmbed.js`);
+const authorReply = require('../util/authorReply.js');
+const { prefix } = require('../components/config.js');
+
+module.exports = {
+	name: 'info',
+	description: 'Information about the bot and its development',
+	category: 'information',
+	permLevel: 'User',
+	noArgs: true,
+	async execute(message, args) {
+		try {
+			//const botVersion = (await got('https://github.com/wakfi/suki/releases')).body.split('/wakfi/suki/releases/tag/')[1].split('"')[0];
+			const djsVersion = (await got('https://github.com/wakfi/suki/blob/master/package.json', {resolveBodyOnly: true})).split('>discord.js<')[1].split('^')[1].split('<')[0];
+			const embed = new MessageEmbed()
+				.setTitle(`Suki`)
+				.setThumbnail(message.client.user.displayAvatarURL())
+				.setAuthor(`wakfi`, `https://cdn.discordapp.com/attachments/433771480505909248/698752752574005308/wakfi.png`)
+				.setDescription(`This bot was created by <@193160566334947340> for the Clue Crew Server`)
+				.addField(`Prefix`,`Use ${prefix} or ${message.client.user} to invoke commands`)
+				.addField(`Help commands`,`${prefix}help, ${prefix}commands, ${prefix}command, ${prefix}?`)
+				.addField(`Library`,`Created in JavaScript using [discord.js](https://discord.js.org/) v${djsVersion}, a powerful node.js module that allows you to interact with the Discord API very easily`)
+				.addField(`Repository`,`This software is licensed under the MIT license. The GitHub repository for this project can be found at: https://github.com/wakfi/suki`)
+				//.setFooter(`Suki ${botVersion}`)
+				.setTimestamp(new Date())
+				.setColor(0xFF00FF);
+			authorReply(message, embed);
+		} catch (error) {
+			console.error(error);
+		}
+	}
+};

--- a/src/commands/info.js
+++ b/src/commands/info.js
@@ -17,7 +17,6 @@ module.exports = {
 			const embed = new MessageEmbed()
 				.setTitle(`Suki`)
 				.setThumbnail(message.client.user.displayAvatarURL())
-				.setAuthor(`wakfi`, `https://cdn.discordapp.com/attachments/433771480505909248/698752752574005308/wakfi.png`)
 				.setDescription(`This bot was created by <@193160566334947340> for the Clue Crew Server`)
 				.addField(`Prefix`,`Use ${prefix} or ${message.client.user} to invoke commands`)
 				.addField(`Help commands`,`${prefix}help, ${prefix}commands, ${prefix}command, ${prefix}?`)

--- a/src/commands/kill.js
+++ b/src/commands/kill.js
@@ -1,0 +1,11 @@
+module.exports = {
+	name: 'kill',
+	description: 'Emergency Kill switch to restart the bot and log an error',
+	category: 'bot management',
+	permLevel: 'Moderator',
+	noArgs: true,
+	async execute(message, args) {
+		console.error(`KILL COMMAND EXECUTED HERE`); //leaves a clear message in the log to make the location easy to find,
+		process.exit(1);							 //in the event i want to know where in the log this occurred. exits with error.
+	}
+};

--- a/src/commands/loadCommand.js
+++ b/src/commands/loadCommand.js
@@ -14,9 +14,9 @@ module.exports = {
 			const command = require(`./${commandName}.js`);
 			message.client.commands.set(command.name, command);
 			message.reply(`Loaded ${command.name} successfully`);
-		} catch (error) {
-			console.error(error);
-			message.channel.send(`There was an error while loading a command \`${commandName}\`:\n\`${error.message}\``);
+		} catch (e) {
+			console.error(e.stack);
+			message.channel.send(`There was an error while loading a command \`${commandName}\`:\n\`${e.message}\``);
 		}
 	}
 };

--- a/src/commands/loadCommand.js
+++ b/src/commands/loadCommand.js
@@ -13,7 +13,7 @@ module.exports = {
 		try {
 			const command = require(`./${commandName}.js`);
 			message.client.commands.set(command.name, command);
-			message.reply(`Loaded ${command.name} successfully`);
+			message.reply(`Loaded \`${command.name}\` successfully`);
 		} catch (e) {
 			console.error(e.stack);
 			message.channel.send(`There was an error while loading a command \`${commandName}\`:\n\`${e.message}\``);

--- a/src/commands/loadCommand.js
+++ b/src/commands/loadCommand.js
@@ -2,7 +2,7 @@ module.exports = {
 	name: 'loadCommand',
 	description: 'Load a new command that is not currently cached into the available commands',
 	category: 'development',
-	usage: '<commandName>',
+	usage: ['<commandName>'],
 	aliases: ['ldc'],
 	permLevel: 'Bot Developer',
 	guildOnly: false,

--- a/src/commands/loadCommand.js
+++ b/src/commands/loadCommand.js
@@ -1,0 +1,22 @@
+module.exports = {
+	name: 'loadCommand',
+	description: 'Load a new command that is not currently cached into the available commands',
+	category: 'development',
+	usage: '<commandName>',
+	aliases: ['ldc'],
+	permLevel: 'Bot Developer',
+	guildOnly: false,
+	dmOnly: false,
+	args: true,
+	async execute(message, args) {
+		const commandName = args.shift();
+		try {
+			const command = require(`./${commandName}.js`);
+			message.client.commands.set(command.name, command);
+			message.reply(`Loaded ${command.name} successfully`);
+		} catch (error) {
+			console.error(error);
+			message.channel.send(`There was an error while loading a command \`${commandName}\`:\n\`${error.message}\``);
+		}
+	}
+};

--- a/src/commands/ping.js
+++ b/src/commands/ping.js
@@ -1,10 +1,12 @@
 module.exports = {
 	name: 'ping',
 	description: 'Ping! Provides information about the bot\'s current connection latency',
+	category: 'basic',
 	permLevel: 'User',
 	guildOnly: false,
 	dmOnly: false,
 	args: false,
+	noArgs: true,
 	async execute(message, args) {
 		const m = await message.channel.send("🏓 Ping?");
 		m.edit(`🏓 Pong! Latency is ${m.createdTimestamp - message.createdTimestamp}ms. API Latency is ${Math.round(message.client.ws.ping)}ms`);

--- a/src/commands/ping.js
+++ b/src/commands/ping.js
@@ -1,7 +1,7 @@
 module.exports = {
 	name: 'ping',
 	description: 'Ping! Provides information about the bot\'s current connection latency',
-	category: 'basic',
+	category: 'general',
 	permLevel: 'User',
 	guildOnly: false,
 	dmOnly: false,

--- a/src/commands/profile.js
+++ b/src/commands/profile.js
@@ -1,0 +1,110 @@
+const path = require('path');
+const MessageEmbed = require((require.resolve('discord.js')).split(path.sep).slice(0, -1).join(path.sep) + `${path.sep}structures${path.sep}MessageEmbed.js`);
+const cleanReply = require('../util/cleanReply.js');
+const selfDeleteReply = require('../util/selfDeleteReply.js');
+const millisecondsToString = require('../util/millisecondsToString.js');
+const printTimePretty = require('../util/printTimePretty.js');
+const USERS_PATTERN = /<@!?(\d{17,18})>/i
+const DISCORD_EPOCH = 1420070400000 //unix of first second of 2015
+
+String.prototype.startsWithIgnoreCase = function(searchString, position)
+{
+	if(typeof position === 'undefined') position = 0;
+	const searching = this.toLowerCase();
+	const search = searchString.toLowerCase();
+	return searching.startsWith(search, position);	
+}
+
+const basicUserProfile = async (message, args) => {
+	let user;
+	if(args.length > 0)
+	{
+		const joinArgs = args.join(' ');
+		const toResolve = USERS_PATTERN.test(joinArgs) ? USERS_PATTERN.exec(joinArgs)[1] : joinArgs;
+		try	{
+			const manager = message.client.users;
+			user = await manager.fetch(manager.resolveID(toResolve));
+		} catch(e) {
+			return selfDeleteReply(message, `Could not resolve "${joinArgs}" to a user`);
+		}
+	} else {
+		user = message.author;
+	}
+	const accountCreationTimestamp = (user.id/Math.pow(2,22)) + DISCORD_EPOCH;
+	const accountCreationTime = new Date(accountCreationTimestamp); //calculate user account creation timestamp
+	const accountCreationTimeDays = printTimePretty(millisecondsToString(Math.trunc((Date.now() - accountCreationTimestamp)/1000)*1000), 'd');
+	const embed = new MessageEmbed()
+		.setThumbnail(user.displayAvatarURL())
+		.setColor(0xFF00FF)
+		.setTitle(`User Profile`)
+		.setDescription(`Profile data for ${user}:`)
+		.addField(`Username & Discriminator:`, user.tag, true)
+		.addField(`ID:`, user.id, true)
+		.addField(`Created Discord Account:`, `${accountCreationTime.toLocaleString('en-US',{year:'numeric',month:'numeric',day:'numeric'})} ${accountCreationTime.toLocaleTimeString(undefined,{hour12:true})}\n(${accountCreationTimeDays})`, true)
+		.setTimestamp(new Date())
+		.setFooter(`Requested by: ${message.author.tag}`, message.author.displayAvatarURL());
+	message.channel.send(embed);
+}
+
+module.exports = {
+	name: 'profile',
+	description: 'Display information about a user in the server',
+	category: 'general',
+	usage: ['[member resolvable]'],
+	permLevel: 'User',
+	async execute(message, args) {
+		if(message.channel.type === 'dm')
+		{
+			basicUserProfile(message, args);
+		} else {
+			let member;
+			if(args.length > 0)
+			{
+				const joinArgs = args.join(' ');
+				const toResolve = USERS_PATTERN.test(joinArgs) ? USERS_PATTERN.exec(joinArgs)[1] : joinArgs;
+				const manager = message.guild.members;
+				try	{
+					member = await manager.fetch(manager.resolveID(toResolve));
+				} catch(e) {
+					member = manager.cache.find(member => member.displayName.startsWith(joinArgs));
+					if(member == null)
+					{
+						return basicUserProfile(message, args);
+					}
+				}
+			} else {
+				member = message.member;
+			}
+			const accountCreationTimestamp = (member.id/Math.pow(2,22)) + DISCORD_EPOCH;
+			const accountCreationTime = new Date(accountCreationTimestamp); //calculate user account creation timestamp
+			const cliStatus = member.presence.clientStatus;
+			const currentDevice = member.user.bot 	? 'Bot' :
+								  cliStatus.desktop ? 'Desktop' : 
+								  cliStatus.web		? 'Web Browser' :
+								  cliStatus.mobile	? 'Mobile' :
+													  'Unknown Client';
+			const status = member.presence.status.charAt(0).toUpperCase() + member.presence.status.slice(1);
+			const richActivity = member.presence.activities.length > 0 ? member.presence.activities[0] : 'None';
+			const currentActivityString = richActivity.type ? `**${richActivity.type.charAt(0).toUpperCase()}${richActivity.type.slice(1).toLowerCase()} ${richActivity}** for ${printTimePretty(millisecondsToString(Date.now() - richActivity.createdTimestamp),'largest unit available')}` : richActivity;
+			const premiumSinceDays = member.premiumSinceTimestamp ? printTimePretty(millisecondsToString(Math.trunc((Date.now() - member.joinedAtTimestamp)/1000)*1000), 'd') : '';
+			const accountCreationTimeDays = printTimePretty(millisecondsToString(Math.trunc((Date.now() - accountCreationTimestamp)/1000)*1000), 'd');
+			const joinedAtDays = printTimePretty(millisecondsToString(Math.trunc((Date.now() - member.joinedTimestamp)/1000)*1000), 'd');
+			const embed = new MessageEmbed()
+				.setThumbnail(member.user.displayAvatarURL())
+				.setColor(0xFF00FF)
+				.setTitle(`User Profile`)
+				.setDescription(`Profile data for ${member}:`)
+				.addField(`Username & Discriminator:`, member.user.tag, true)
+				.addField(`ID:`, member.id, true)
+				.addField(`Server Booster?`, `${member.premiumSinceTimestamp ? 'Since ' + member.premiumSince.toLocaleString('en-US',{year:'numeric',month:'numeric',day:'numeric'}) + ' ' + member.premiumSince.toLocaleTimeString(undefined,{hour12:true}) + '\n(' + premiumSinceDays + ')'  : 'No'}`, true)
+				.addField(`Highest Role:`, member.roles.highest, true)
+				.addField(`Status`, `${status} on ${currentDevice}`, true)
+				.addField(`Current Activity`, currentActivityString, true)
+				.addField(`Created Discord Account:`, `${accountCreationTime.toLocaleString('en-US',{year:'numeric',month:'numeric',day:'numeric'})} ${accountCreationTime.toLocaleTimeString(undefined,{hour12:true})}\n(${accountCreationTimeDays})`, true)
+				.addField(`Joined the Server:`, `${member.joinedAt.toLocaleString('en-US',{year:'numeric',month:'numeric',day:'numeric'})} ${member.joinedAt.toLocaleTimeString(undefined,{hour12:true})}\n(${joinedAtDays})`, true)
+				.setTimestamp(new Date())
+				.setFooter(`Requested by: ${message.author.tag}`, message.author.displayAvatarURL());
+			message.channel.send(embed);
+		}
+	}
+};

--- a/src/commands/purge.js
+++ b/src/commands/purge.js
@@ -4,7 +4,7 @@ module.exports = {
 	name: 'purge',
 	description: 'Bulk deletes a specific amount of recent messages',
 	category: 'moderation',
-	usage: '<number of messages>\ncount | <number of messages>\nfrom | <messageID>\nbetween | <olderMessageID> | <newerMessageID>',
+	usage: ['<number of messages>', 'count | <number of messages>', 'from | <messageID>', 'between | <olderMessageID> | <newerMessageID>'],
 	aliases: null,
 	permLevel: 'Moderator',
 	guildOnly: true,

--- a/src/commands/purge.js
+++ b/src/commands/purge.js
@@ -1,0 +1,108 @@
+const cleanReply = require('../util/cleanReply.js');
+
+module.exports = {
+	name: 'purge',
+	description: 'Bulk deletes a specific amount of recent messages',
+	category: 'moderation',
+	usage: '<number of messages>\ncount | <number of messages>\nfrom | <messageID>\nbetween | <olderMessageID> | <newerMessageID>',
+	aliases: null,
+	permLevel: 'Moderator',
+	guildOnly: true,
+	dmOnly: false,
+	args: true,
+	async execute(message, args) {
+		// This command removes all messages from all users in the channel, up to 100
+		const manager = message.channel.messages;
+		const lastAccessibleMessageID = (await manager.fetch({limit: 1, before: message.channel.lastMessageID})).first().id;
+		let keyword;
+		let deleteCount = 100;
+		let fetchOptions = null;
+		let startID = null;
+		let endID = message.channel.lastMessageID;
+		let afterID = null;
+		if(!args.includes(`|`))
+		{
+			// get the delete count, as an actual number.
+			deleteCount = parseInt(args[0], 10) + 1;
+			
+			fetchOptions = {limit: deleteCount};
+		} else {
+			let pipedArgs = args.join(" ").split("|");
+			pipedArgs = pipedArgs.map(arg => arg.trim().toLowerCase());
+			keyword = pipedArgs.shift();
+			if(keyword === "from")
+			{
+				startID = pipedArgs.shift();
+				if(!manager.resolveID(startID))
+				{
+					return cleanReply(message, `Must provide a valid message ID`);
+				}
+				const afterResult = await manager.fetch({limit: 1, before: startID});
+				afterID = (afterResult.size == 1) ? afterResult.first().id : startID;
+				fetchOptions = {limit: deleteCount, after: afterID};
+			} else if(keyword === `between`) {
+				startID = pipedArgs.shift();
+				endID = pipedArgs.shift();
+				if(endID === lastAccessibleMessageID)
+				{
+					//changes execution to a 'from' command for simplicity, as the range selected is from some message
+					//to the bottom, which is what 'from' does
+					args[0] = `from`;
+					await execute(message, args);
+					return;
+				} else {
+					if(!manager.resolveID(startID) || !manager.resolveID(endID))
+					{
+						return await cleanReply(message, `Please provide valid message IDs`);
+					}
+					const afterResult = await manager.fetch({limit: 1, before: startID});
+					const beforeResult = await manager.fetch({limit: 1, after: endID});
+					afterID = (afterResult.size == 1) ? afterResult.first().id : startID;
+					const beforeID = (beforeResult.size == 1) ? beforeResult.first().id : endID;
+					
+					const afterMessages = await manager.fetch({limit: 100, after: afterID});
+					const beforeMessages = await manager.fetch({limit: 100, before: beforeID});
+
+					const intersectionMessages = afterMessages.filter(msg => beforeMessages.has(msg.id));
+					deleteCount = intersectionMessages.size;
+					
+					fetchOptions = {limit: deleteCount, after: afterID};
+				}
+			} else if(keyword === "count") {
+				// get the delete limit, as an actual number.
+				deleteCount = parseInt(pipedArgs.shift(), 10) + 1;
+				
+				fetchOptions = {limit: deleteCount};
+			} else {
+				return cleanReply(message, `Unknown purge command: ${keyword}`);
+			}
+		}
+		
+		if(isNaN(deleteCount))
+		{
+			return cleanReply(message, `Number of messages to delete must be a number`);
+		}
+		
+		// combined conditions <3 user must input between 2-99
+		if(!deleteCount || deleteCount < 3 || deleteCount > 100)
+		{
+			return cleanReply(message, `Please provide a number between 2 and 99 (inclusive) for the number of messages to delete`);
+		}
+		
+		// So we get our messages, and delete them. Simple enough, right?
+		const fetched = await manager.fetch(fetchOptions);
+		
+		if(!fetched.has(endID) || startID && !fetched.has(startID))
+		{
+			const errText = keyword === "from" ? `Message ID must be within 99 messages of the most recent message` :
+												 `The older message provided must be within 99 messages of the newer message`;
+			return cleanReply(message, errText);
+		}
+		
+		message.channel.bulkDelete(fetched)
+		.catch(async error => 
+		{
+			cleanReply(message, `Couldn't delete messages because of: ${error}`);
+		});
+	}
+};

--- a/src/commands/reloadCommand.js
+++ b/src/commands/reloadCommand.js
@@ -18,7 +18,7 @@ module.exports = {
 				delete require.cache[require.resolve(`./${command.name}.js`)];
 				const newCommand = require(`./${command.name}.js`);
 				message.client.commands.set(newCommand.name, newCommand);
-				message.reply(`Reloaded ${command.name} successfully`);
+				message.reply(`Reloaded \`${command.name}\` successfully`);
 			} catch (e) {
 				console.error(e.stack);
 				message.channel.send(`There was an error while reloading a command \`${command.name}\`:\n\`${e.message}\``);

--- a/src/commands/reloadCommand.js
+++ b/src/commands/reloadCommand.js
@@ -2,7 +2,7 @@ module.exports = {
 	name: 'reloadCommand',
 	description: 'Reload a command that is currently cached in the available commands',
 	category: 'development',
-	usage: '<commandName>',
+	usage: ['<commandName>'],
 	aliases: ['rlc'],
 	permLevel: 'Bot Developer',
 	guildOnly: false,

--- a/src/commands/reloadCommand.js
+++ b/src/commands/reloadCommand.js
@@ -1,0 +1,29 @@
+module.exports = {
+	name: 'reloadCommand',
+	description: 'Reload a command that is currently cached in the available commands',
+	category: 'development',
+	usage: '<commandName>',
+	aliases: ['rlc'],
+	permLevel: 'Bot Developer',
+	guildOnly: false,
+	dmOnly: false,
+	args: true,
+	async execute(message, args) {
+		const commandName = args.shift();
+		try { 
+			const command = message.client.commands.get(commandName) ||
+							message.client.commands.find(cmd => cmd.aliases && cmd.aliases.includes(commandName));
+			try {
+				delete require.cache[require.resolve(`./${command.name}.js`)];
+				const newCommand = require(`./${command.name}.js`);
+				message.client.commands.set(newCommand.name, newCommand);
+				message.reply(`Reloaded ${command.name} successfully`);
+			} catch (e) {
+				console.error(e);
+				message.channel.send(`There was an error while reloading a command \`${command.name}\`:\n\`${e.message}\``);
+			}
+		} catch(e) {
+			return message.channel.send(`There is currently no command with name or alias \`${commandName}\` loaded`);
+		}
+	}
+};

--- a/src/commands/reloadCommand.js
+++ b/src/commands/reloadCommand.js
@@ -13,13 +13,14 @@ module.exports = {
 		try { 
 			const command = message.client.commands.get(commandName) ||
 							message.client.commands.find(cmd => cmd.aliases && cmd.aliases.includes(commandName));
+			const cn = command.name;
 			try {
 				delete require.cache[require.resolve(`./${command.name}.js`)];
 				const newCommand = require(`./${command.name}.js`);
 				message.client.commands.set(newCommand.name, newCommand);
 				message.reply(`Reloaded ${command.name} successfully`);
 			} catch (e) {
-				console.error(e);
+				console.error(e.stack);
 				message.channel.send(`There was an error while reloading a command \`${command.name}\`:\n\`${e.message}\``);
 			}
 		} catch(e) {

--- a/src/commands/restart.js
+++ b/src/commands/restart.js
@@ -1,0 +1,10 @@
+module.exports = {
+	name: 'restart',
+	description: 'Normal restart. The process manager (pm2) will restart it automatically',
+	category: 'bot management',
+	permLevel: 'Moderator',
+	noArgs: true,
+	async execute(message, args) {
+		process.exit(0);
+	}
+};

--- a/src/commands/unloadCommand.js
+++ b/src/commands/unloadCommand.js
@@ -1,0 +1,28 @@
+module.exports = {
+	name: 'unloadCommand',
+	description: 'Remove a command from the currently available commands',
+	category: 'development',
+	usage: '<commandName>',
+	aliases: ['ulc'],
+	permLevel: 'Bot Developer',
+	guildOnly: false,
+	dmOnly: false,
+	args: true,
+	async execute(message, args) {
+		const commandName = args.shift();
+		try { 
+			const command = message.client.commands.get(commandName) ||
+							message.client.commands.find(cmd => cmd.aliases && cmd.aliases.includes(commandName));
+			try {
+				delete require.cache[require.resolve(`./${command.name}.js`)];
+				message.client.commands.sweep(cmd => cmd.name === command.name);
+				message.reply(`Successfully unloaded ${command.name}`);
+			} catch (e) {
+				console.error(e);
+				message.channel.send(`There was an error while unloading a command \`${command.name}\`:\n\`${e.message}\``);
+			}
+		} catch(e) {
+			message.channel.send(`There is currently no command with name or alias \`${commandName}\` loaded`);
+		}
+	}
+};

--- a/src/commands/unloadCommand.js
+++ b/src/commands/unloadCommand.js
@@ -2,7 +2,7 @@ module.exports = {
 	name: 'unloadCommand',
 	description: 'Remove a command from the currently available commands',
 	category: 'development',
-	usage: '<commandName>',
+	usage: ['<commandName>'],
 	aliases: ['ulc'],
 	permLevel: 'Bot Developer',
 	guildOnly: false,

--- a/src/commands/unloadCommand.js
+++ b/src/commands/unloadCommand.js
@@ -18,10 +18,10 @@ module.exports = {
 				message.client.commands.sweep(cmd => cmd.name === command.name);
 				message.reply(`Successfully unloaded ${command.name}`);
 			} catch (e) {
-				console.error(e);
+				console.error(e.stack);
 				message.channel.send(`There was an error while unloading a command \`${command.name}\`:\n\`${e.message}\``);
 			}
-		} catch(e) {
+		} catch(er) {
 			message.channel.send(`There is currently no command with name or alias \`${commandName}\` loaded`);
 		}
 	}

--- a/src/commands/unloadCommand.js
+++ b/src/commands/unloadCommand.js
@@ -16,7 +16,7 @@ module.exports = {
 			try {
 				delete require.cache[require.resolve(`./${command.name}.js`)];
 				message.client.commands.sweep(cmd => cmd.name === command.name);
-				message.reply(`Successfully unloaded ${command.name}`);
+				message.reply(`Successfully unloaded \`${command.name}\``);
 			} catch (e) {
 				console.error(e.stack);
 				message.channel.send(`There was an error while unloading a command \`${command.name}\`:\n\`${e.message}\``);

--- a/src/commands/uptime.js
+++ b/src/commands/uptime.js
@@ -1,0 +1,50 @@
+const path = require('path');
+const MessageEmbed = require((require.resolve('discord.js')).split(path.sep).slice(0, -1).join(path.sep) + `${path.sep}structures${path.sep}MessageEmbed.js`);
+const replaceLast = require('../util/replaceLast.js');
+
+module.exports = {
+	name: 'uptime',
+	description: 'Displays the current time the bot has been connected to Discord',
+	category: 'general',
+	permLevel: 'User',
+	noArgs: true,
+	async execute(message, args) {
+		function pad(n, z) {
+			z = z || 1;
+			return ('00' + n).slice(-z);
+		}
+		let s = message.client.uptime;
+		let ms = s % 1000;
+		s = (s - ms) / 1000;
+		let secs = s % 60;
+		s = (s - secs) / 60;
+		let mins = s % 60;
+		let h = (s - mins) / 60;
+		let hours = h % 24;
+		let days = (h - hours) / 24;
+		let p = Math.floor(Math.log10(days)) + 1;
+		if(Math.log10(days) < 1) {
+			p = false;
+		}
+		let uptimeArgs = [];
+		if(days) uptimeArgs.push(`**${days}** ${days>1?'days':'day'}`);
+		if(hours) uptimeArgs.push(`**${hours}** ${hours>1?'hours':'hour'}`);
+		if(mins) uptimeArgs.push(`**${mins}** ${mins>1?'minutes':'minute'}`);
+		if(secs) uptimeArgs.push(`**${secs}** ${secs>1?'seconds':'second'}`);
+		let uptimeString = `I have been running for ${uptimeArgs.join(', ')}`;
+		if(/,/.test(uptimeString))
+		{
+			if((uptimeString.match(/,/g) || []).length > 1)
+			{
+				uptimeString = replaceLast(uptimeString, ',', ', and')
+			} else {
+				uptimeString = replaceLast(uptimeString, ',', ' and')
+			}
+		}
+		const embed = new MessageEmbed()
+			.setTitle(`Uptime`)
+			.setDescription(uptimeString)
+			.setColor(0xFF00FF);
+		message.channel.send(embed);
+	}
+};

--- a/src/suki.js
+++ b/src/suki.js
@@ -56,7 +56,7 @@ client.on("message", async message => {
 	if(message.author.bot) return; 
 	
 	const args = message.content.slice(prefix.length).split(/ +/g);
-	if(USERS_PATTERN.test(message.content))
+	if(USERS_PATTERN.test(message.content) && message.content.startsWith(`${message.client.user}`))
 	{
 		args.shift(); //clear mention
 		if(args.length == 0) return cleanReply(message, `type \`${prefix}help\` to see a list commands`, `15s`);

--- a/src/suki.js
+++ b/src/suki.js
@@ -1,6 +1,7 @@
 function main(){
 const Discord = require('discord.js');
 const fs = require('fs-extra');
+const USERS_PATTERN = /<@!?\d{17,18}>/i
 
 const { prefix, token, clientOptions, activity, clientStatus, permLevels } = require('./components/config.js');
 
@@ -50,24 +51,30 @@ client.once("ready", async () => {
 
 //this event triggers when a message is sent in a channel the bot has access to
 client.on("message", async message => {
-	if(!message.content.startsWith(prefix)) return;
+	if(!message.content.startsWith(prefix) && !message.mentions.has(client.user)) return;
+	
 	if(message.author.bot) return; 
-
+	
 	const args = message.content.slice(prefix.length).split(/ +/g);
+	if(USERS_PATTERN.test(message.content))
+	{
+		args.shift(); //clear mention
+		if(args.length == 0) return cleanReply(message, `type \`${prefix}help\` to see a list commands`, `15s`);
+	}
 	const commandName = args.shift();
 	
 	const command = client.commands.get(commandName) || 
 					client.commands.find(cmd => cmd.aliases && cmd.aliases.includes(commandName));
 					
 	if(!command) return;
-					
+		
 	if(args.join(' ') === '-h') return client.commands.get('help').execute(message,[commandName]);
 	
 	if(command.guildOnly && message.channel.type !== 'text') return message.channel.send(`This command cannot be executed in DMs!`);
 	
 	if(command.dmOnly && message.channel.type !== 'dm') return cleanReply(message, `This command can only be executed in DMs!`);
 	
-	if(((args.length==0) && command.args) || (args.length > 0 && command.noArgs))
+	if((args.length==0 && command.args) || (args.length > 0 && command.noArgs))
 	{
 		let reply = `Invalid command syntax. Try sending me \`${prefix}${command.name} -h\` for help with this command`;
 		return cleanReply(message, reply, '20s');

--- a/src/suki.js
+++ b/src/suki.js
@@ -63,15 +63,15 @@ client.on("message", async message => {
 					
 	if(args.join(' ') === '-h') return client.commands.get('help').execute(message,args,commandName);
 	
+	if(command.guildOnly && message.channel.type !== 'text') return message.channel.send(`This command cannot be executed in DMs!`);
+	
+	if(command.dmOnly && message.channel.type !== 'dm') return cleanReply(message, `This command can only be executed in DMs!`);
+	
 	if(!((args.length==0) ^ command.args)) 
 	{
 		let reply = `Invalid command syntax. Try sending me \`${prefix}${command.name} -h\` for help with this command`;
 		return cleanReply(message, reply, '20s');
 	}
-	
-	if(command.guildOnly && message.channel.type !== 'text') return cleanReply(message, `This command cannot be executed in DMs!`);
-	
-	if(command.dmOnly && message.channel.type !== 'dm') return cleanReply(message, `This command can only be executed in DMs!`);
 	
 	const level = permlevel(message);
 	if(level < levelCache[command.permLevel]) return cleanReply(message, `You don't have permission to use this command`);

--- a/src/suki.js
+++ b/src/suki.js
@@ -61,13 +61,13 @@ client.on("message", async message => {
 					
 	if(!command) return;
 					
-	if(args.join(' ') === '-h') return client.commands.get('help').execute(message,args,commandName);
+	if(args.join(' ') === '-h') return client.commands.get('help').execute(message,[commandName]);
 	
 	if(command.guildOnly && message.channel.type !== 'text') return message.channel.send(`This command cannot be executed in DMs!`);
 	
 	if(command.dmOnly && message.channel.type !== 'dm') return cleanReply(message, `This command can only be executed in DMs!`);
 	
-	if(!((args.length==0) ^ command.args)) 
+	if(((args.length==0) && command.args) || (args.length > 0 && command.noArgs))
 	{
 		let reply = `Invalid command syntax. Try sending me \`${prefix}${command.name} -h\` for help with this command`;
 		return cleanReply(message, reply, '20s');

--- a/src/util/authorReply.js
+++ b/src/util/authorReply.js
@@ -1,3 +1,5 @@
+const path = require('path');
+const Message = require((require.resolve('discord.js')).split(path.sep).slice(0, -1).join(path.sep) + `${path.sep}structures${path.sep}Message.js`);
 const cleanReply = require('./cleanReply.js');
 
 function authorReply(message, input)
@@ -5,12 +7,13 @@ function authorReply(message, input)
 	return new Promise(async (resolve,reject) =>
 	{
 		if(typeof message === "undefined") throw new TypeError(`message is undefined`);
-		if(!(message instanceof Discord.Message)) throw new TypeError(`message is not Discord Message`);
+		if(!(message instanceof Message)) throw new TypeError(`message is not Discord Message`);
 		if(typeof input === "undefined") input = "an unknown error occured";
 		try {
 			await message.author.send(input);
 		} catch(e) {
 			cleanReply(`It looks like I can't DM you. Do you have DMs disabled?`);
+			reject(false);
 		}
 		resolve();
 	});

--- a/src/util/cleanReply.js
+++ b/src/util/cleanReply.js
@@ -1,4 +1,5 @@
-const Message = require((require.resolve('discord.js')).split('\\').slice(0, -1).join('\\') + '\\structures\\Message.js');
+const path = require('path');
+const Message = require((require.resolve('discord.js')).split(path.sep).slice(0, -1).join(path.sep) + `${path.sep}structures${path.sep}Message.js`);
 const delay = require('./delay.js');
 
 function cleanReply(message, input, duration)

--- a/src/util/cleanReply.js
+++ b/src/util/cleanReply.js
@@ -10,7 +10,7 @@ function cleanReply(message, input, duration)
 		if(typeof input === "undefined") input = "an unknown error occured";
 		if(typeof duration === "undefined") duration = "12s";
 		const errReply = await message.reply(input);
-		if(duration == 0 || message.channel.type === 'dm') resolve();
+		if(duration == 0 || message.channel.type === 'dm') {resolve(); return;}
 		await delay(duration);
 		await errReply.delete();
 		try {

--- a/src/util/isTimeFormat.js
+++ b/src/util/isTimeFormat.js
@@ -1,0 +1,19 @@
+function isTimeFormat(input)
+{
+	if(!/(?<=\d)[ywdhms]|(?<=m)s?/gi.test(input)) return false;
+	if(/[^ywdhms\dxbeoacf.-]/gi.test(input)) return false;
+	let regStrings = ['^'];
+	if(/(?:(?<=^)(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))y(?=[\d-]|$))/gi.test(input)) regStrings.push('(?:(?<=^)(-?(?:\\d*|0b[01]+|0o[0-7]+|\\d+(?:\\.\\d+)?e-?\\d+|0x[\\dabcedf]+))y(?=[\\d-]|$))');
+	if(/(?:(?<=^|[y])(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))w(?=[\d-]|$))/gi.test(input)) regStrings.push('(?:(?<=^|[y])(-?(?:\\d*|0b[01]+|0o[0-7]+|\\d+(?:\\.\\d+)?e-?\\d+|0x[\\dabcedf]+))w(?=[\\d-]|$))');
+	if(/(?:(?<=^|[yw])(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))d(?=[\d-]|$))/gi.test(input)) regStrings.push('(?:(?<=^|[yw])(-?(?:\\d*|0b[01]+|0o[0-7]+|\\d+(?:\\.\\d+)?e-?\\d+|0x[\\dabcedf]+))d(?=[\\d-]|$))');
+	if(/(?:(?<=^|[ywd])(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))h(?=[\d-]|$))/gi.test(input)) regStrings.push('(?:(?<=^|[ywd])(-?(?:\\d*|0b[01]+|0o[0-7]+|\\d+(?:\\.\\d+)?e-?\\d+|0x[\\dabcedf]+))h(?=[\\d-]|$))');
+	if(/(?:(?<=^|[ywdh])(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))m(?=[\d-]|$))/gi.test(input)) regStrings.push('(?:(?<=^|[ywdh])(-?(?:\\d*|0b[01]+|0o[0-7]+|\\d+(?:\\.\\d+)?e-?\\d+|0x[\\dabcedf]+))m(?=[\\d-]|$))');
+	if(/(?:(?<=^|[ywdhm])(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))s(?=[\d-]|$))/gi.test(input)) regStrings.push('(?:(?<=^|[ywdhm])(-?(?:\\d*|0b[01]+|0o[0-7]+|\\d+(?:\\.\\d+)?e-?\\d+|0x[\\dabcedf]+))s(?=[\\d-]|$))');
+	if(/(?:(?<=^|[ywdhms])(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))ms(?=$))/gi.test(input)) regStrings.push('(?:(?<=^|[ywdhms])(-?(?:\\d*|0b[01]+|0o[0-7]+|\\d+(?:\\.\\d+)?e-?\\d+|0x[\\dabcedf]+))ms(?=$))');
+	if(regStrings.length == 1) return false;
+	regStrings.push('$');
+	const pattern = new RegExp(regStrings.join(''), 'gi');
+	return pattern.test(input);
+}
+
+module.exports = isTimeFormat;

--- a/src/util/millisecondsToString.js
+++ b/src/util/millisecondsToString.js
@@ -1,0 +1,48 @@
+/*
+
+ milliseconds into a human readable string
+ 
+*/
+function millisecondsToString(milliseconds)
+{
+	if(isNaN(milliseconds))
+	{
+		throw new TypeError(`milliseconds must be a number`);
+	}
+	let timeString = ``;
+	let days = 0;
+	let hours = 0;
+	let minutes = 0;
+	let seconds = 0;
+	seconds = Math.trunc(milliseconds/1000);
+	minutes = Math.trunc(seconds/60);
+	hours = Math.trunc(minutes/60);
+	days = Math.trunc(hours/24);
+	milliseconds = milliseconds % 1000;
+	seconds = seconds % 60;
+	minutes = minutes % 60;
+	hours = hours % 24;
+	if(days != 0)
+	{
+		timeString += `${days}d`
+	}
+	if(hours != 0)
+	{
+		timeString += `${hours}h`
+	}
+	if(minutes != 0)
+	{
+		timeString += `${minutes}m`
+	}
+	if(seconds != 0)
+	{
+		timeString += `${seconds}s`
+	}
+	if(milliseconds != 0)
+	{
+		timeString += `${milliseconds}ms`
+	}
+	return timeString;
+}
+
+module.exports = millisecondsToString;

--- a/src/util/parseTime.js
+++ b/src/util/parseTime.js
@@ -1,3 +1,4 @@
+const isTimeFormat = require('./isTimeFormat.js');
 
 /*
 
@@ -19,18 +20,18 @@ function parseTime(timeToParse)
 	if(isNaN(timeToParse))
 	{
 		const timeString = timeToParse;
-		if(/[^ymwdhms](?<=m)s?/.test(timeString))
+		if(!isTimeFormat(timeString))
 		{
-			timeValue = timeToParse;
+			throw new SyntaxError('must be in the format 1d 2h 3m 4s 5ms (any segment is optional, such as `1h 1m` is valid)');
 		} else {
 			let match = null;
-			const yearReg = /(\d+)y/gi;
-			const weekReg = /(\d+)w/gi;
-			const dayReg = /(\d+)d/gi;
-			const hourReg = /(\d+)h/gi;
-			const minReg = /(\d+)m(?!s)/gi;
-			const secReg = /(\d+)s/gi;
-			const msReg = /(\d+)ms/gi;
+			const yearReg = /(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))y/gi;
+			const weekReg = /(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))w/gi;
+			const dayReg = /(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))d/gi;
+			const hourReg = /(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))h/gi;
+			const minReg = /(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))m(?!s)/gi;
+			const secReg = /(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))s/gi;
+			const msReg = /(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))ms/gi;
 			let years = 0;
 			let weeks = 0;
 			let days = 0;
@@ -41,43 +42,43 @@ function parseTime(timeToParse)
 			match = yearReg.exec(timeString);
 			if(match !== null)
 			{
-				years = +match[1];
+				years = Number(match[1]);
 			}
 			match = null;
 			match = weekReg.exec(timeString);
 			if(match !== null)
 			{
-				weeks = +match[1];
+				weeks = Number(match[1]);
 			}
 			match = null;
 			match = dayReg.exec(timeString);
 			if(match !== null)
 			{
-				days = +match[1];
+				days = Number(match[1]);
 			}
 			match = null;
 			match = hourReg.exec(timeString);
 			if(match !== null)
 			{
-				hours = +match[1];
+				hours = Number(match[1]);
 			}
 			match = null;
 			match = minReg.exec(timeString);
 			if(match !== null)
 			{
-				minutes = +match[1];
+				minutes = Number(match[1]);
 			}
 			match = null;
 			match = secReg.exec(timeString);
 			if(match !== null)
 			{
-				seconds = +match[1];
+				seconds = Number(match[1]);
 			}
 			match = null;
 			match = msReg.exec(timeString);
 			if(match !== null)
 			{
-				milliseconds = +match[1];
+				milliseconds = Number(match[1]);
 			}
 			days += 365*years;
 			days += 7*weeks;

--- a/src/util/printTimePretty.js
+++ b/src/util/printTimePretty.js
@@ -1,0 +1,89 @@
+const isTimeFormat = require('./isTimeFormat.js');
+const parseTime = require('./parseTime.js');
+const millisecondsToString = require('./millisecondsToString.js');
+const replaceLast = require('./replaceLast.js');
+const stringFormatRegex = /^((?:\d+)(?=y))?((?:\d+)(?=w))?((?:\d+)(?=d))?((?:\d+)(?=h))?((?:\d+)(?=m))?((?:\d+)(?=s))?((?:\d+)(?=ms))?$/gi
+const unitSizes = {'l':0,'y':7,'w':6,'d':5,'h':4,'m':3,'s':2,'ms':1};
+
+function printTimePretty(readableTime, smallestUnit)
+{
+	const yearReg = /(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))y/gi;
+	const weekReg = /(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))w/gi;
+	const dayReg = /(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))d/gi;
+	const hourReg = /(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))h/gi;
+	const minReg = /(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))m(?!s)/gi;
+	const secReg = /(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))s/gi;
+	const msReg = /(-?(?:\d+|0b[01]+|0o[0-7]+|\d+(?:\.\d+)?e-?\d+|0x[\dabcedf]+))ms/gi;
+	if(!isTimeFormat(readableTime)) throw new SyntaxError(`invalid readableTime: ${readableTime}`);
+	let unit = 0;
+	let smUnit = '';
+	if(typeof smallestUnit !== 'undefined')
+	{
+		smUnit = smallestUnit.charAt(0).toLowerCase();
+		if(smUnit === 'm' && (smallestUnit.toLowerCase() === 'ms' || smallestUnit.toLowerCase() === 'milliseconds')) smUnit = 'ms';
+		unit = unitSizes[smUnit];
+	}
+	let match = null;
+	let allMatches = [];
+	match = yearReg.exec(readableTime);
+	if(match !== null)
+	{
+		allMatches.push(`${Number(match[1])} ${Number(match[1])>1?'years':'year'}`);
+		if(smUnit === 'l') unit = 8;
+	}
+	match = null;
+	match = weekReg.exec(readableTime);
+	if(match !== null && unit <= unitSizes['w'])
+	{
+		allMatches.push(`${Number(match[1])} ${Number(match[1])>1?'weeks':'week'}`);
+		if(smUnit === 'l') unit = 8;
+	}
+	match = null;
+	match = dayReg.exec(readableTime);
+	if(match !== null && unit <= unitSizes['d'])
+	{
+		allMatches.push(`${Number(match[1])} ${Number(match[1])>1?'days':'day'}`);
+		if(smUnit === 'l') unit = 8;
+	}
+	match = null;
+	match = hourReg.exec(readableTime);
+	if(match !== null && unit <= unitSizes['h'])
+	{
+		allMatches.push(`${Number(match[1])} ${Number(match[1])>1?'hours':'hour'}`);
+		if(smUnit === 'l') unit = 8;
+	}
+	match = null;
+	match = minReg.exec(readableTime);
+	if(match !== null && unit <= unitSizes['m'])
+	{
+		allMatches.push(`${Number(match[1])} ${Number(match[1])>1?'minutes':'minute'}`);
+		if(smUnit === 'l') unit = 8;
+	}
+	match = null;
+	match = secReg.exec(readableTime);
+	if(match !== null && unit <= unitSizes['s'])
+	{
+		allMatches.push(`${Number(match[1])} ${Number(match[1])>1?'seconds':'second'}`);
+		if(smUnit === 'l') unit = 8;
+	}
+	match = null;
+	match = msReg.exec(readableTime);
+	if(match !== null && unit <= unitSizes['ms'])
+	{
+		allMatches.push(`${Number(match[1])} ${Number(match[1])>1?'milliseconds':'millisecond'}`);
+		if(smUnit === 'l') unit = 8;
+	}
+	let prettyTime = allMatches.join(', ');
+	if(/,/.test(prettyTime))
+	{
+		if((prettyTime.match(/,/g) || []).length > 1)
+		{
+			upreadableTime = replaceLast(prettyTime, ',', ', and')
+		} else {
+			upreadableTime = replaceLast(prettyTime, ',', ' and')
+		}
+	}
+	return prettyTime;
+}
+
+module.exports = printTimePretty;

--- a/src/util/replaceLast.js
+++ b/src/util/replaceLast.js
@@ -1,0 +1,9 @@
+String.prototype.reverse = function() {
+    return this.split('').reverse().join('');
+};
+
+function replaceLast(string, substring, replacement) {
+    return string.reverse().replace(new RegExp(substring.reverse()), replacement.reverse()).reverse();
+};
+
+module.exports = replaceLast;

--- a/src/util/selfDeleteReply.js
+++ b/src/util/selfDeleteReply.js
@@ -1,0 +1,20 @@
+const path = require('path');
+const Message = require((require.resolve('discord.js')).split(path.sep).slice(0, -1).join(path.sep) + `${path.sep}structures${path.sep}Message.js`);
+const delay = require('./delay.js');
+
+function selfDeleteReply(message, input, duration)
+{
+	return new Promise(async (resolve,reject) =>
+	{
+		if(!(message instanceof Message)) throw new TypeError(`message is not Discord Message`);
+		if(typeof input === "undefined") input = "an unknown error occured";
+		if(typeof duration === "undefined") duration = "15s";
+		const errReply = await message.reply(input);
+		if(duration == 0) resolve();
+		await delay(duration);
+		await errReply.delete();
+		resolve();
+	});
+}
+
+module.exports = selfDeleteReply;


### PR DESCRIPTION
Minor adjustments to command handler
A small suite of basic commands that are nice (in some cases very important) to have. The list of commands and required permission levels: 
- ping: everyone
- uptime: everyone
- info: everyone
- help: everyone
- profile: everyone
- kill: moderator
- restart: moderator
- purge: moderator
- loadCommand (ldc): bot developer
- unloadCommand (ulc): bot developer
- reloadCommand (rlc): bot developer

A large number of `util` files are now present to enable current functions and should also be useful moving forwards